### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,2 +1,2 @@
-dls-controls git@github.com:dls-controls/ADOdin.git
+DiamondLightSource git@github.com:DiamondLightSource/ADOdin.git
 gitolite ssh://dascgitolite@dasc-git.diamond.ac.uk/controls/support/ADOdin


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/ADOdin` using https://gitlab.diamond.ac.uk/github/github-scripts